### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,12 @@
 Certificate Manager Plugin Changelog
 </h1>
 
+<p><b>1.2.0</b> -- (tbd)</p>
+<ul>
+    <li>Requires Openfire 4.8.0.</li>
+    <li><a href="https://github.com/igniterealtime/openfire-certificateManager-plugin/issues/19">#19</a>: Compatibility with Openfire 4.9.0.</li>
+</ul>
+
 <p><b>1.1.1</b> -- July 20, 2023</p>
 <ul>
     <li>Added Portuguese translations (by Miguel Veiga)</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,9 +5,8 @@
     <description>Adds certificate management features.</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2023-07-20</date>
-    <minServerVersion>4.3.0 alpha</minServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <date>2024-09-06</date>
+    <minServerVersion>4.8.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-certificates">

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-beta</version>
+        <version>4.8.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>certificatemanager</artifactId>

--- a/src/java/org/igniterealtime/openfire/plugins/certificatemanager/DirectoryWatcher.java
+++ b/src/java/org/igniterealtime/openfire/plugins/certificatemanager/DirectoryWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class DirectoryWatcher
     private static final Logger Log = LoggerFactory.getLogger( DirectoryWatcher.class );
 
     public static final String PROPERTY_WATCHED_PATH = "certificate-manager.directory-watcher.watched-path";
-    public static final String PROPERTY_WATCHED_PATH_DEFAULT = JiveGlobals.getHomeDirectory() + File.separator + "resources" + File.separator + "security" + File.separator + "hotdeploy" + File.separator;
+    public static final String PROPERTY_WATCHED_PATH_DEFAULT = JiveGlobals.getHomePath().resolve("resources" + File.separator + "security" + File.separator + "hotdeploy" + File.separator).toString();
     public static final String PROPERTY_ENABLED = "certificate-manager.directory-watcher.enabled";
     public static final boolean PROPERTY_ENABLED_DEFAULT = true;
     public static final String PROPERTY_REPLACE = "certificate-manager.directory-watcher.replace";


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

This plugin is now compatible with Openfire 4.9.0 and requires 4.8.0 or later. No longer compatible with versions older than 4.8.0.

fixes #19